### PR TITLE
Replace node-native-zip with archiver and trim extra whitespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "jade": "*",
     "wrench": "~1.3.9",
     "async": "~0.1.22",
-    "node-native-zip": "git://github.com/donnfelker/node-native-zip.git#master"
+    "archiver": "0.14.3"
   },
-  "repository": "https://github.com/donnfelker/android-bootstrap-site.git",
+  "repository": "https://github.com/bryansills/android-bootstrap-site.git",
   "engines": {
     "node": "10.26.x",
     "npm": "1.4.3"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "async": "~0.1.22",
     "archiver": "0.14.3"
   },
-  "repository": "https://github.com/bryansills/android-bootstrap-site.git",
+  "repository": "https://github.com/donnfelker/android-bootstrap-site.git",
   "engines": {
     "node": "10.26.x",
     "npm": "1.4.3"

--- a/routes/generate.js
+++ b/routes/generate.js
@@ -3,21 +3,21 @@ var wrench = require('wrench'),
     spawn = require('child_process').spawn,
     fs = require('fs'),
     async = require('async'),
-    zip = require("node-native-zip");
+    archiver = require("archiver");
 /*
- * Project generator route. 
- * This entire route is super brute force and rather naive. However, it works and is easy to follow. 
+ * Project generator route.
+ * This entire route is super brute force and rather naive. However, it works and is easy to follow.
  * TODO: Possible improvements include doing more async calls with the fs module since this uses the async.js
- * lib it shouldn't be too bad to impelement. 
+ * lib it shouldn't be too bad to impelement.
 */
 exports.index = function(req, res) {
 
-    // 1. Create a temporary file(s) location. 
-    // 2. Rename the directories accordingly. 
-    // 3. Loop over all the files and perform replacements. 
+    // 1. Create a temporary file(s) location.
+    // 2. Rename the directories accordingly.
+    // 3. Loop over all the files and perform replacements.
     // 4. Zip up the content & Send to the output stream
-    // 5. Delete the temporary file(s). 
-    // 6. All Done - Do some 12 ounce curls. 
+    // 5. Delete the temporary file(s).
+    // 6. All Done - Do some 12 ounce curls.
 
     console.log(process.env.PWD);
 
@@ -29,14 +29,14 @@ exports.index = function(req, res) {
 
     // Android Bootstrap ource directory
     var sourceDir = process.env.PWD + '/android-bootstrap';
-    
+
     // Temporary locationwhere the users project will be generated.
-    var destDir = process.env.PWD + '/tmp/' + packageName; 
+    var destDir = process.env.PWD + '/tmp/' + packageName;
 
     console.log("sourceDir: " + sourceDir);
-    console.log("destDir: " + destDir); 
+    console.log("destDir: " + destDir);
 
-    // Copy the files to temp directory. 
+    // Copy the files to temp directory.
     wrench.copyDirSyncRecursive(sourceDir, destDir);
 
     var theFiles = wrench.readdirSyncRecursive(destDir);
@@ -52,49 +52,43 @@ exports.index = function(req, res) {
     });
 
     async.parallel(callItems, function(err, results) {
-      
+
       if(err) {
         console.error("**** ERROR ****");
       } else {
-        
+
         // Now, all items have been executed, perform the copying/etc.
         createSourceDirectories(destDir, packageName);
-        copySourceDirectories(destDir, packageName); 
-        removeBootstrapDirectories(destDir); 
-        
+        copySourceDirectories(destDir, packageName);
+        removeBootstrapDirectories(destDir);
+
         sendContentAsZip(destDir, res);
 
       }
-    }); 
+    });
 }
 
 function sendContentAsZip(destDir, res) {
-  
+
   var fileObjects = getFileObjectsFrom(destDir, wrench.readdirSyncRecursive(destDir));
-  
-  var archive = new zip();
-  archive.addFiles(fileObjects, function(err) {
-    if(err) {
-      console.log(err);
-      res.statusCode = 500;
-      res.end(); 
-    } else {
-      
-      archive.toBuffer(function(buff) {
-        
-        res.contentType('zip');
-        res.setHeader('Content-disposition', 'attachment; filename=android-bootstrap.zip');
-        res.send(buff);
-        res.end();        
 
-        wrench.rmdirSyncRecursive(destDir, false)
-      }); 
+  var archive = archiver('zip');
 
-      
-    }
-      
+  res.setHeader('Content-disposition', 'attachment; filename=android-bootstrap.zip');
+
+  archive.pipe(res);
+
+  fileObjects.forEach(function(item) {
+    archive.append(fs.createReadStream(item.path), { name: item.name });
   });
- 
+
+  archive.finalize(function(err) {
+      if (err) {
+        throw err;
+      }
+  });
+
+  wrench.rmdirSyncRecursive(destDir, false)
 }
 
 function getFileObjectsFrom(destDir, files) {
@@ -118,61 +112,61 @@ function removeBootstrapDirectories(destDir) {
 
   // TODO: remove the old bootstrap source, unit-test and integration-test folders that are not valid anymore.
   console.log("Removing temporary work directories.");
-  
-  // Clean up - delete all the files we were just working with. 
-  var bootstrapSourceDir = destDir + "/app/src/main/java/com/donnfelker"; 
-  var bootstrapUnitTestDir = destDir + "/app/src/test/java/com/donnfelker"; 
-  var integrationTestDir = destDir +  "/integration-tests/src/main/java/com/donnfelker"; 
+
+  // Clean up - delete all the files we were just working with.
+  var bootstrapSourceDir = destDir + "/app/src/main/java/com/donnfelker";
+  var bootstrapUnitTestDir = destDir + "/app/src/test/java/com/donnfelker";
+  var integrationTestDir = destDir +  "/integration-tests/src/main/java/com/donnfelker";
 
   console.log("Removing: " + bootstrapSourceDir);
   console.log("Removing: " + bootstrapUnitTestDir);
   console.log("Removing: " + integrationTestDir);
-  
+
   wrench.rmdirSyncRecursive(bootstrapSourceDir, false);
   wrench.rmdirSyncRecursive(bootstrapUnitTestDir, false);
   wrench.rmdirSyncRecursive(integrationTestDir, false);
 
 }
 
-// Creates the various new folder structures needed for the users new project. 
+// Creates the various new folder structures needed for the users new project.
 function createSourceDirectories(destDir, packageName) {
 
   var newPathChunk = getNewFilePath(packageName);
 
-  var newSourceDirectory = destDir + "/app/src/main/java/" + newPathChunk; 
+  var newSourceDirectory = destDir + "/app/src/main/java/" + newPathChunk;
   console.log("Creating new source directory at: " + newSourceDirectory);
-  wrench.mkdirSyncRecursive(newSourceDirectory); 
+  wrench.mkdirSyncRecursive(newSourceDirectory);
 
-  var newUnitTestDirectory = destDir + "/app/src/test/java/" + newPathChunk; 
+  var newUnitTestDirectory = destDir + "/app/src/test/java/" + newPathChunk;
   console.log("Creating new source directory at: " + newUnitTestDirectory);
-  wrench.mkdirSyncRecursive(newUnitTestDirectory); 
+  wrench.mkdirSyncRecursive(newUnitTestDirectory);
 
-  var newIntegrationTestDirectory = destDir + "/integration-tests/src/main/java/" + newPathChunk; 
+  var newIntegrationTestDirectory = destDir + "/integration-tests/src/main/java/" + newPathChunk;
   console.log("Creating new integration tests directory at: " + newIntegrationTestDirectory);
-  wrench.mkdirSyncRecursive(newIntegrationTestDirectory);     
+  wrench.mkdirSyncRecursive(newIntegrationTestDirectory);
 }
 
 function copySourceDirectories(destDir, packageName) {
 
   console.log(destDir);
   console.log(packageName);
-  
+
   var newPathChunk = getNewFilePath(packageName);
 
-  var oldSourceDir = destDir  +  "/app/src/main/java/com/donnfelker/android/bootstrap";  
-  var newSourceDir = destDir    +  "/app/src/main/java/" + newPathChunk; 
+  var oldSourceDir = destDir  +  "/app/src/main/java/com/donnfelker/android/bootstrap";
+  var newSourceDir = destDir    +  "/app/src/main/java/" + newPathChunk;
   console.log("Copying source from" + oldSourceDir + " to directory " + newSourceDir);
-  wrench.copyDirSyncRecursive(oldSourceDir, newSourceDir); 
+  wrench.copyDirSyncRecursive(oldSourceDir, newSourceDir);
 
   var oldUnitTestDir = destDir + "/app/src/test/java/com/donnfelker/android/bootstrap";
-  var newUnitTestDir = destDir + "/app/src/test/java/" + newPathChunk; 
+  var newUnitTestDir = destDir + "/app/src/test/java/" + newPathChunk;
   console.log("Copying source from" + oldUnitTestDir + " to directory " + newUnitTestDir);
-  wrench.copyDirSyncRecursive(oldUnitTestDir, newUnitTestDir); 
+  wrench.copyDirSyncRecursive(oldUnitTestDir, newUnitTestDir);
 
   var oldIntegrationTestDir = destDir + "/integration-tests/src/main/java/com/donnfelker/android/bootstrap";
-  var newIntegrationTestDir = destDir + "/integration-tests/src/main/java/" + newPathChunk; 
+  var newIntegrationTestDir = destDir + "/integration-tests/src/main/java/" + newPathChunk;
   console.log("Copying source from" + oldIntegrationTestDir + " to directory " + newIntegrationTestDir);
-  wrench.copyDirSyncRecursive(oldIntegrationTestDir, newIntegrationTestDir);     
+  wrench.copyDirSyncRecursive(oldIntegrationTestDir, newIntegrationTestDir);
 }
 
 String.prototype.endsWith = function(suffix) {
@@ -182,16 +176,16 @@ String.prototype.endsWith = function(suffix) {
 function generateFile(file, packageName, appName, callback) {
 
   var stats = fs.lstatSync(file);
-  if(!stats.isDirectory() && !file.endsWith(".png")) { 
-    // Only work with text files, no directories or png files.  
+  if(!stats.isDirectory() && !file.endsWith(".png")) {
+    // Only work with text files, no directories or png files.
     // Above == terrible code, but for android-bootstrap, it works. Pragmatic & KISS. FTW.
-    
+
     // Must include the encoding otherwise the raw buffer will
     // be returned as the data.
     var data = fs.readFileSync(file, 'utf-8');
-        
+
     //console.log("Current File: " + file);
-  
+
     console.log("File: " + file);
     // Sure, we could chain these, but this is easier to read.
     data = replacePackageName(data, packageName);
@@ -201,26 +195,26 @@ function generateFile(file, packageName, appName, callback) {
     data = replaceProguardValues(data, packageName);
 
     // Finally all done doing replacing, save this bad mother.
-    fs.writeFileSync(file, data); 
+    fs.writeFileSync(file, data);
   }
 
-   // Call back to async lib. 
+   // Call back to async lib.
     callback(null, file);
 }
 
 
-// Turns a package name into a file path string. 
+// Turns a package name into a file path string.
 // Example: com.foo.bar.bang turns into com\foo\bar\bang
 function getNewFilePath(newPackageName) {
-  return newPackageName.split('.').join('/'); 
+  return newPackageName.split('.').join('/');
 }
 
 function getOldFilePath() {
-  return "com.donnfelker.android.bootstrap".split('.').join('/'); 
+  return "com.donnfelker.android.bootstrap".split('.').join('/');
 }
 
 // Takes the old boostrap file name and returns the new file name
-// that is created via the transform from the new package name. 
+// that is created via the transform from the new package name.
 function getBootstrappedFileName(bootstrapFileName, newPackageName) {
   return bootstrapFileName.replace( getOldFilePath(), getNewFilePath(newPackageName) );
 }
@@ -228,7 +222,7 @@ function getBootstrappedFileName(bootstrapFileName, newPackageName) {
 function replacePackageName(fileContents, newPackageName) {
   var BOOTSTRAP_PACKAGE_NAME = "com.donnfelker.android.bootstrap"; // replace all needs a regex with the /g (global) modifier
   var packageNameRegExp = new RegExp(BOOTSTRAP_PACKAGE_NAME, 'g');
-          
+
   // Replace package name
   return fileContents.replace(packageNameRegExp, newPackageName);
 }
@@ -255,7 +249,7 @@ function replaceHyphenatedNames(fileContents, newPackageName) {
 }
 
 function replaceProguardValues(fileContents, newPackageName) {
-  var newValue = newPackageName + '.'; 
+  var newValue = newPackageName + '.';
   var valueToFind = new RegExp("com.donnfelker.android.", 'g');
 
   return fileContents.replace(valueToFind, newValue);


### PR DESCRIPTION
I didn't want to have to fork the node-native-zip into my own account, so I switched it out for archiver. Should be the same functionally, but if we run into issues with the library, we will have a better chance to get some help. Most relevant changes happen starting at line 74 in generate.js.

I also trimmed a bunch of unnecessary whitespace in the file.